### PR TITLE
Adds option for a custom new tab file

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -11,6 +11,9 @@
   "compat_notice_title": {
     "message": "Es fehlen Funktionen?"
   },
+  "custom_file_description": {
+    "message": "Lade eine HTML-Datei hoch. Alle URLs müssen absolut sein, und file:// URIs funktionieren nicht"
+   },
   "default_option_description": {
     "message": "Zur Verwendung der Standard-Seite von Firefox rufe bitte about:addons auf und deaktiviere die Erweiterung New Tab Override (keine Deinstallation notwendig)."
   },
@@ -91,6 +94,9 @@
   },
   "type_options_background_color": {
     "message": "Hintergrund-Farbe"
+  },
+  "type_options_custom_file": {
+    "message": "eigene Datei"
   },
   "type_options_custom_url": {
     "message": "eigene URL"

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -11,6 +11,9 @@
   "compat_notice_title": {
     "message": "Missing some options?"
   },
+  "custom_file_description": {
+   "message": "Upload a html file. All external resources need to be accessed via full URLs, relative URLs or file:// URIs do not work"
+  },
   "default_option_description": {
     "message": "To use Firefox's default page, please open about:addons and disable the New Tab Override extension (no uninstall required)."
   },
@@ -91,6 +94,9 @@
   },
   "type_options_background_color": {
     "message": "background color"
+  },
+  "type_options_custom_file": {
+    "message": "custom file"
   },
   "type_options_custom_url": {
     "message": "custom URL"

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -32,6 +32,7 @@
               <option value='custom_url'>__MSG_type_options_custom_url__</option>
               <option value='background_color'>__MSG_type_options_background_color__</option>
               <option value='feed'>__MSG_type_options_feed__</option>
+              <option value='custom_file'>__MSG_type_options_custom_file__</option>
             </select>
           </div>
           <div id='default-option' class='hidden'>
@@ -82,6 +83,11 @@
               <a href='#' id='feed-permission-revoke'>__MSG_settings_feed_permission_revoke_action__</a>
             </div>
           </div>
+          <div id='custom-file' class='hidden'>
+              <h3>__MSG_type_options_custom_file__</h3>
+              <input type='file' id='custom-file-upload' accept='.html, .htm' />
+              <div class='info-icon'>__MSG_custom_file_description__</div>
+            </div>
         </form>
       </div>
       <div id='compat-notice' class='hidden'>

--- a/src/js/newtab.js
+++ b/src/js/newtab.js
@@ -44,6 +44,10 @@ const newtab = {
       case 'feed':
         browser.tabs.update({ url : browser.extension.getURL(FEED_PAGE) });
         break;
+      case 'custom_file':
+        let result = await browser.storage.local.get("customNewTabFile");
+        document.body.innerHTML = result.customNewTabFile;
+        break;
       default:
         browser.tabs.update({ url : 'about:blank' });
     }

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -22,6 +22,8 @@ const elType = document.getElementById('type');
 const elUrl = document.getElementById('url');
 const elUrlOption = document.getElementById('url-option');
 const elUrlWrapper = document.getElementById('url-wrapper');
+const elCustomFile = document.getElementById("custom-file");
+const elCustomFileUpload = document.getElementById("custom-file-upload");
 
 /**
  * @exports options
@@ -53,6 +55,7 @@ const options = {
     let showFocusOption = false;
     let showClearOption = false;
     let showBackgroundColorOption = false;
+    let showCustomFileOption = false;
 
     // default new tab page
     if (elType.options[elType.selectedIndex].value === 'default') {
@@ -77,11 +80,17 @@ const options = {
       showClearOption = true;
     }
 
+    // custom file
+    if(elType.options[elType.selectedIndex].value === 'custom_file') {
+      showCustomFileOption = true;
+    }
+
     options.toggleVisibility(elDefaultOption, showDisableNotice);
     options.toggleVisibility(elUrlOption, showUrlOption);
     options.toggleVisibility(elFocusOption, showFocusOption);
     options.toggleVisibility(elClearOption, showClearOption);
     options.toggleVisibility(elBackgroundColorOption, showBackgroundColorOption);
+    options.toggleVisibility(elCustomFile, showCustomFileOption);
   },
 
   /**
@@ -192,6 +201,9 @@ elType.addEventListener('change', (e) => {
     elFeedPermissionRevoke.classList.add('hidden');
   }
 
+  if (e.target.value !== 'custom-file') {
+    browser.storage.local.set({customNewTabFile: ''});
+  }
   browser.storage.local.set({ type : e.target.value });
   options.toggleOptionsDetails();
 });
@@ -213,4 +225,13 @@ elUrl.addEventListener('input', (e) => {
 
 elBackgroundColor.addEventListener('input', (e) => {
   browser.storage.local.set({ background_color : e.target.value });
+});
+
+elCustomFileUpload.addEventListener("change", (e) => {
+  let reader = new FileReader();
+  reader.readAsText(elCustomFileUpload.files[0]);
+  reader.addEventListener("loadend", () => {
+    let file = reader.result;
+    browser.storage.local.set({customNewTabFile: file});
+  });
 });


### PR DESCRIPTION
Adding the option for a custom new tab. The user can "upload" (rather: load) a file, which is then saved into  browser.storage.local. That way, it can even load external resources, if they are hosted on a website, not via file://.
I added the German and English messages, I do not speak the other two.
**EDIT:** Forgot to update the version number in the manifest, you'll have to do that in case you merge. My bad, 'tschuldigung.