### PR TITLE
Fix: tab container is lost when "Set focus to the web page instead of the address bar" option is used

### DIFF
--- a/src/js/core/newtab.js
+++ b/src/js/core/newtab.js
@@ -94,7 +94,7 @@ const newtab = {
     if (focus_website) {
       await browser.tabs.getCurrent((tab) => {
         const tabId = tab.id;
-        browser.tabs.create({ url : url || 'about:blank' }, () => {
+        browser.tabs.create({ url : url || 'about:blank', cookieStoreId : tab.cookieStoreId }, () => {
           browser.tabs.remove(tabId);
         });
       });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -41,6 +41,7 @@
   "permissions": [
     "history",
     "storage",
+    "cookies",
     "tabs"
   ],
   "optional_permissions": [


### PR DESCRIPTION
Mentioned in #53