### PR TITLE
fix about:blank option fail when custom url is configured

### DIFF
--- a/src/js/core/newtab.js
+++ b/src/js/core/newtab.js
@@ -20,13 +20,14 @@ const newtab = {
    */
   async init () {
     const options = await browser.storage.local.get(defaults);
-    const url = options.type === 'about:home' ? options.type : options.url;
 
     switch (options.type) {
       case 'about:blank':
       case 'about:home':
+        newtab.openNewTabPage(options.type, options.focus_website);
+        break;
       case 'custom_url':
-        newtab.openNewTabPage(url, options.focus_website);
+        newtab.openNewTabPage(options.url, options.focus_website);
         break;
       case 'homepage':
         const isAllowed = await browser.permissions.contains(PERMISSION_HOMEPAGE);


### PR DESCRIPTION
Bug reproduce:

1. Chose Custom URL
2. Enter some valid URL (e.g. https://www.example.com/ )
3. Chose blank page (about:blank)
4. Open a new tab

Expect: Open about:blank
Actual: Open example.com