### PR TITLE
Forget sourceTab if they are in the same container

### DIFF
--- a/src/js/core/newtab.js
+++ b/src/js/core/newtab.js
@@ -125,6 +125,8 @@ class NewTab {
         else {
           sourceTab = otherTabs.sort((a, b) => b.lastAccessed - a.lastAccessed)[0] ?? null;
         }
+        // The sourceTab only matters if they are in different cookieStore.
+        sourceTab = sourceTab.cookieStoreId !== tab.cookieStoreId ? sourceTab : null;
       }
 
       const createdTabProperties = {


### PR DESCRIPTION
Would fix #391 if they are in the same, default container