### PR TITLE
Add custom URL iFrame mode

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -65,6 +65,9 @@
   "context_rules_url_label": {
     "message": "URL"
   },
+  "custom_url_iframe_warning": {
+    "message": "Viele Websites lassen sich nicht in einem iFrame einbinden. Setzt der Betreiber entsprechende Sicherheitsregeln (X-Frame-Options oder Content-Security-Policy), bleibt die eingebettete Seite leer."
+  },
   "extension_description": {
     "message": "Mit New Tab Override kann die Seite festgelegt werden, welche beim Öffnen eines neuen Tabs angezeigt wird."
   },
@@ -193,6 +196,9 @@
   },
   "type_options_custom_url": {
     "message": "Benutzerdefinierte URL"
+  },
+  "type_options_custom_url_iframe": {
+    "message": "Benutzerdefinierte URL (iFrame)"
   },
   "type_options_feed": {
     "message": "Mozilla-Neuigkeiten"

--- a/src/_locales/dsb/messages.json
+++ b/src/_locales/dsb/messages.json
@@ -65,6 +65,9 @@
   "context_rules_url_label": {
     "message": "URL"
   },
+  "custom_url_iframe_warning": {
+    "message": "Many websites cannot be embedded in an iFrame. If the website owner sets the appropriate security rules (X-Frame-Options or Content-Security-Policy), the embedded page will remain blank."
+  },
   "extension_description": {
     "message": "Z New Tab Override móžoš bok póstajiś, kótaryž se pśi wócynjanju nowego rejtarka pokazujo."
   },
@@ -193,6 +196,9 @@
   },
   "type_options_custom_url": {
     "message": "Wót wužywarja definěrowany URL"
+  },
+  "type_options_custom_url_iframe": {
+    "message": "Custom URL (iFrame)"
   },
   "type_options_feed": {
     "message": "Nowinki Mozilla (nimski)"

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -65,6 +65,9 @@
   "context_rules_url_label": {
     "message": "URL"
   },
+  "custom_url_iframe_warning": {
+    "message": "Many websites cannot be embedded in an iFrame. If the website owner sets the appropriate security rules (X-Frame-Options or Content-Security-Policy), the embedded page will remain blank."
+  },
   "extension_description": {
     "message": "New Tab Override allows you to set the page that shows whenever you open a new tab."
   },
@@ -193,6 +196,9 @@
   },
   "type_options_custom_url": {
     "message": "Custom URL"
+  },
+  "type_options_custom_url_iframe": {
+    "message": "Custom URL (iFrame)"
   },
   "type_options_feed": {
     "message": "Mozilla News (German)"

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -65,6 +65,9 @@
   "context_rules_url_label": {
     "message": "URL"
   },
+  "custom_url_iframe_warning": {
+    "message": "Many websites cannot be embedded in an iFrame. If the website owner sets the appropriate security rules (X-Frame-Options or Content-Security-Policy), the embedded page will remain blank."
+  },
   "extension_description": {
     "message": "New Tab Override allows you to set the page that shows whenever you open a new tab."
   },
@@ -193,6 +196,9 @@
   },
   "type_options_custom_url": {
     "message": "URL personalizada"
+  },
+  "type_options_custom_url_iframe": {
+    "message": "Custom URL (iFrame)"
   },
   "type_options_feed": {
     "message": "Noticias de Mozilla (Alemán)"

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -65,6 +65,9 @@
   "context_rules_url_label": {
     "message": "URL"
   },
+  "custom_url_iframe_warning": {
+    "message": "De nombreux sites web ne peuvent pas être intégrés dans un iFrame. Si l'administrateur définit des règles de sécurité correspondantes (X-Frame-Options ou Content-Security-Policy), la page intégrée reste vide."
+  },
   "extension_description": {
     "message": "New Tab Override vous permet de définir la page qui s'affiche à chaque fois que vous ouvrez un nouvel onglet."
   },
@@ -193,6 +196,9 @@
   },
   "type_options_custom_url": {
     "message": "URL personnalisée"
+  },
+  "type_options_custom_url_iframe": {
+    "message": "URL personnalisée (iFrame)"
   },
   "type_options_feed": {
     "message": "Actualité Mozilla (en allemand)"

--- a/src/_locales/hsb/messages.json
+++ b/src/_locales/hsb/messages.json
@@ -65,6 +65,9 @@
   "context_rules_url_label": {
     "message": "URL"
   },
+  "custom_url_iframe_warning": {
+    "message": "Many websites cannot be embedded in an iFrame. If the website owner sets the appropriate security rules (X-Frame-Options or Content-Security-Policy), the embedded page will remain blank."
+  },
   "extension_description": {
     "message": "Z New Tab Override móžeš stronu postajić, kotraž so při wočinjenju noweho rajtarka pokazuje."
   },
@@ -193,6 +196,9 @@
   },
   "type_options_custom_url": {
     "message": "Wot wužiwarja definowany URL"
+  },
+  "type_options_custom_url_iframe": {
+    "message": "Custom URL (iFrame)"
   },
   "type_options_feed": {
     "message": "Nowinki Mozilla (němsce)"

--- a/src/_locales/id/messages.json
+++ b/src/_locales/id/messages.json
@@ -65,6 +65,9 @@
   "context_rules_url_label": {
     "message": "URL"
   },
+  "custom_url_iframe_warning": {
+    "message": "Many websites cannot be embedded in an iFrame. If the website owner sets the appropriate security rules (X-Frame-Options or Content-Security-Policy), the embedded page will remain blank."
+  },
   "extension_description": {
     "message": "New Tab Override memungkinkan Anda untuk menyetel halaman secara otomatis setiap kali Anda membuka tab baru."
   },
@@ -193,6 +196,9 @@
   },
   "type_options_custom_url": {
     "message": "URL khusus"
+  },
+  "type_options_custom_url_iframe": {
+    "message": "Custom URL (iFrame)"
   },
   "type_options_feed": {
     "message": "Berita Mozilla (Indonesian)"

--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -65,6 +65,9 @@
   "context_rules_url_label": {
     "message": "URL"
   },
+  "custom_url_iframe_warning": {
+    "message": "Many websites cannot be embedded in an iFrame. If the website owner sets the appropriate security rules (X-Frame-Options or Content-Security-Policy), the embedded page will remain blank."
+  },
   "extension_description": {
     "message": "New Tab Override allows you to set the page that shows whenever you open a new tab."
   },
@@ -193,6 +196,9 @@
   },
   "type_options_custom_url": {
     "message": "URL personalizzato"
+  },
+  "type_options_custom_url_iframe": {
+    "message": "Custom URL (iFrame)"
   },
   "type_options_feed": {
     "message": "Novità Mozilla (Tedesco)"

--- a/src/_locales/nl/messages.json
+++ b/src/_locales/nl/messages.json
@@ -65,6 +65,9 @@
   "context_rules_url_label": {
     "message": "URL"
   },
+  "custom_url_iframe_warning": {
+    "message": "Many websites cannot be embedded in an iFrame. If the website owner sets the appropriate security rules (X-Frame-Options or Content-Security-Policy), the embedded page will remain blank."
+  },
   "extension_description": {
     "message": "Met New Tab Override kunt u de pagina instellen die bij het openen van een nieuw tabblad wordt weergegeven."
   },
@@ -193,6 +196,9 @@
   },
   "type_options_custom_url": {
     "message": "Aangepaste URL"
+  },
+  "type_options_custom_url_iframe": {
+    "message": "Custom URL (iFrame)"
   },
   "type_options_feed": {
     "message": "Mozilla-nieuws (Duits)"

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -65,6 +65,9 @@
   "context_rules_url_label": {
     "message": "URL"
   },
+  "custom_url_iframe_warning": {
+    "message": "Many websites cannot be embedded in an iFrame. If the website owner sets the appropriate security rules (X-Frame-Options or Content-Security-Policy), the embedded page will remain blank."
+  },
   "extension_description": {
     "message": "New Tab Override pozwala na ustawienie strony, która wyświetlana jest po każdym otwarciu nowej karty."
   },
@@ -193,6 +196,9 @@
   },
   "type_options_custom_url": {
     "message": "Niestandardowy adres URL"
+  },
+  "type_options_custom_url_iframe": {
+    "message": "Custom URL (iFrame)"
   },
   "type_options_feed": {
     "message": "Aktualności Mozilli (Niemiecki)"

--- a/src/_locales/pt-BR/messages.json
+++ b/src/_locales/pt-BR/messages.json
@@ -65,6 +65,9 @@
   "context_rules_url_label": {
     "message": "URL"
   },
+  "custom_url_iframe_warning": {
+    "message": "Many websites cannot be embedded in an iFrame. If the website owner sets the appropriate security rules (X-Frame-Options or Content-Security-Policy), the embedded page will remain blank."
+  },
   "extension_description": {
     "message": "New Tab Override allows you to set the page that shows whenever you open a new tab."
   },
@@ -193,6 +196,9 @@
   },
   "type_options_custom_url": {
     "message": "URL personalizada"
+  },
+  "type_options_custom_url_iframe": {
+    "message": "Custom URL (iFrame)"
   },
   "type_options_feed": {
     "message": "Noticias da Mozilla (alemão)"

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -65,6 +65,9 @@
   "context_rules_url_label": {
     "message": "URL"
   },
+  "custom_url_iframe_warning": {
+    "message": "Many websites cannot be embedded in an iFrame. If the website owner sets the appropriate security rules (X-Frame-Options or Content-Security-Policy), the embedded page will remain blank."
+  },
   "extension_description": {
     "message": "New Tab Override allows you to set the page that shows whenever you open a new tab."
   },
@@ -193,6 +196,9 @@
   },
   "type_options_custom_url": {
     "message": "Пользовательский URL-адрес"
+  },
+  "type_options_custom_url_iframe": {
+    "message": "Custom URL (iFrame)"
   },
   "type_options_feed": {
     "message": "Новости Mozilla (German)"

--- a/src/_locales/sv-SE/messages.json
+++ b/src/_locales/sv-SE/messages.json
@@ -65,6 +65,9 @@
   "context_rules_url_label": {
     "message": "URL"
   },
+  "custom_url_iframe_warning": {
+    "message": "Many websites cannot be embedded in an iFrame. If the website owner sets the appropriate security rules (X-Frame-Options or Content-Security-Policy), the embedded page will remain blank."
+  },
   "extension_description": {
     "message": "New Tab Override låter dig ställa in den sidan som visas när du öppnar en ny flik."
   },
@@ -193,6 +196,9 @@
   },
   "type_options_custom_url": {
     "message": "Egen URL"
+  },
+  "type_options_custom_url_iframe": {
+    "message": "Custom URL (iFrame)"
   },
   "type_options_feed": {
     "message": "Mozilla nyheter (Tyska)"

--- a/src/_locales/tr/messages.json
+++ b/src/_locales/tr/messages.json
@@ -65,6 +65,9 @@
   "context_rules_url_label": {
     "message": "URL"
   },
+  "custom_url_iframe_warning": {
+    "message": "Many websites cannot be embedded in an iFrame. If the website owner sets the appropriate security rules (X-Frame-Options or Content-Security-Policy), the embedded page will remain blank."
+  },
   "extension_description": {
     "message": "New Tab Override yeni bir sekme açtığınızda gösterilecek sayfayı seçmenizi sağlar."
   },
@@ -193,6 +196,9 @@
   },
   "type_options_custom_url": {
     "message": "Özel URL"
+  },
+  "type_options_custom_url_iframe": {
+    "message": "Custom URL (iFrame)"
   },
   "type_options_feed": {
     "message": "Mozilla Haberleri (Almanca)"

--- a/src/_locales/uk-UA/messages.json
+++ b/src/_locales/uk-UA/messages.json
@@ -65,6 +65,9 @@
   "context_rules_url_label": {
     "message": "URL"
   },
+  "custom_url_iframe_warning": {
+    "message": "Many websites cannot be embedded in an iFrame. If the website owner sets the appropriate security rules (X-Frame-Options or Content-Security-Policy), the embedded page will remain blank."
+  },
   "extension_description": {
     "message": "New Tab Override дозволяє налаштувати сторінку, що буде відкриватися у новій вкладці."
   },
@@ -193,6 +196,9 @@
   },
   "type_options_custom_url": {
     "message": "Користувацький URL"
+  },
+  "type_options_custom_url_iframe": {
+    "message": "Custom URL (iFrame)"
   },
   "type_options_feed": {
     "message": "Новини Mozilla (Німецькою)"

--- a/src/_locales/zh-CN/messages.json
+++ b/src/_locales/zh-CN/messages.json
@@ -65,6 +65,9 @@
   "context_rules_url_label": {
     "message": "URL"
   },
+  "custom_url_iframe_warning": {
+    "message": "Many websites cannot be embedded in an iFrame. If the website owner sets the appropriate security rules (X-Frame-Options or Content-Security-Policy), the embedded page will remain blank."
+  },
   "extension_description": {
     "message": "New Tab Override allows you to set the page that shows whenever you open a new tab."
   },
@@ -193,6 +196,9 @@
   },
   "type_options_custom_url": {
     "message": "自定义网址"
+  },
+  "type_options_custom_url_iframe": {
+    "message": "Custom URL (iFrame)"
   },
   "type_options_feed": {
     "message": "Mozilla 新闻（德语）"

--- a/src/css/newtab.css
+++ b/src/css/newtab.css
@@ -1,3 +1,15 @@
+body.iframe-mode {
+  margin: 0;
+  overflow: hidden;
+}
+
+iframe.newtab-frame {
+  display: block;
+  width: 100vw;
+  height: 100vh;
+  border: 0;
+}
+
 @media (prefers-color-scheme: dark) {
   body {
     background-color: rgb(28, 27, 34);

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -51,6 +51,7 @@
                 <select name="type" id="type">
                   <option data-i18n="type_options_homepage" value="homepage"></option>
                   <option data-i18n="type_options_custom_url" value="custom_url"></option>
+                  <option data-i18n="type_options_custom_url_iframe" value="custom_url_iframe"></option>
                   <option data-i18n="type_options_local_file" value="local_file"></option>
                   <option data-i18n="type_options_background_color" value="background_color"></option>
                   <option data-i18n="type_options_feed" value="feed"></option>
@@ -59,6 +60,9 @@
             </div>
             <div id="homepage-option" class="hidden type-option-detail">
               <div data-i18n="homepage_description" class="info-icon option-content"></div>
+            </div>
+            <div id="custom-url-iframe-option" class="hidden type-option-detail">
+              <div data-i18n="custom_url_iframe_warning" class="info-icon option-content"></div>
             </div>
             <div id="local-file-option" class="hidden type-option-detail">
               <div class="info-icon option-content">

--- a/src/js/core/newtab.js
+++ b/src/js/core/newtab.js
@@ -18,6 +18,63 @@ class NewTab {
   static #feedPage = 'html/feed.html';
 
   /**
+   * Resolve URL input for custom URL modes, including random selection when multiple URLs are configured.
+   *
+   * @param {string} url - configured URL(s)
+   * @param {boolean} hasUrlRules - whether any context URL rules are configured
+   *
+   * @returns {{isValid: boolean, openOptionsPage: boolean, url: string}} - resolved URL and fallback behavior
+   */
+  static #resolveCustomUrl (url, hasUrlRules) {
+    let resolvedUrl = url;
+
+    if (resolvedUrl.indexOf('|') > -1) {
+      const urls = url.split('|');
+      const randIndex = Math.floor(Math.random() * urls.length);
+
+      resolvedUrl = urls[randIndex].trim();
+    }
+
+    if (!Utils.uriRegex.test(resolvedUrl)) {
+      return {
+        isValid: false,
+        openOptionsPage: resolvedUrl.trim() !== '' || !hasUrlRules,
+        url: ''
+      };
+    }
+
+    return {
+      isValid: true,
+      openOptionsPage: true,
+      url: resolvedUrl
+    };
+  }
+
+  /**
+   * Render a custom URL inside an iframe on the internal new tab page.
+   *
+   * @param {string} url - URL to load in the iframe
+   * @param {boolean} focusWebsite - whether focus should move into the embedded page
+   *
+   * @returns {void}
+   */
+  static #openNewTabIFrame (url, focusWebsite) {
+    const $frame = document.createElement('iframe');
+
+    document.body.classList.add('iframe-mode');
+    $frame.classList.add('newtab-frame');
+    $frame.src = url;
+
+    if (focusWebsite) {
+      $frame.addEventListener('load', () => {
+        $frame.focus();
+      }, { once: true });
+    }
+
+    document.body.appendChild($frame);
+  }
+
+  /**
    * This method is used to navigate to the set new tab page.
    *
    * @returns {Promise<void>}
@@ -54,31 +111,30 @@ class NewTab {
       }
     }
 
-    let { type, url } = options;
+    const { type, url } = options;
     const contextUrl = await NewTab.#findContextUrl(options, managedKeys, tab, contextTab);
-
-    if (contextUrl) {
-      type = 'custom_url';
-      url = contextUrl;
-    }
+    const resolvedUrl = contextUrl || url;
 
     switch (type) {
       case 'custom_url':
-        if (url.indexOf('|') > -1) {
-          const urls = url.split('|');
-          const randIndex = Math.floor(Math.random() * urls.length);
-          url = urls[randIndex].trim();
-        }
+        const customUrl = NewTab.#resolveCustomUrl(resolvedUrl, hasUrlRules);
 
-        // return early if there is no valid url
-        if (!Utils.uriRegex.test(url)) {
-          const openOptionsPage = url.trim() !== '' || !hasUrlRules;
-
-          await NewTab.#openNewTabPage('', false, tab, openOptionsPage);
+        if (!customUrl.isValid) {
+          await NewTab.#openNewTabPage('', false, tab, customUrl.openOptionsPage);
           break;
         }
 
-        await NewTab.#openNewTabPage(url, options.focus_website, tab);
+        await NewTab.#openNewTabPage(customUrl.url, options.focus_website, tab);
+        break;
+      case 'custom_url_iframe':
+        const iframeUrl = NewTab.#resolveCustomUrl(resolvedUrl, hasUrlRules);
+
+        if (!iframeUrl.isValid) {
+          await NewTab.#openNewTabPage('', false, tab, iframeUrl.openOptionsPage);
+          break;
+        }
+
+        NewTab.#openNewTabIFrame(iframeUrl.url, options.focus_website);
         break;
       case 'homepage':
         const homepage = await browser.browserSettings.homepageOverride.get({});
@@ -136,7 +192,7 @@ class NewTab {
   static async #findContextUrl (options, managedKeys, tab, contextTab) {
     const hasManagedContextRules = managedKeys.includes('context_rules');
 
-    if (options.type !== 'custom_url' ||
+    if (!['custom_url', 'custom_url_iframe'].includes(options.type) ||
         (!hasManagedContextRules && (managedKeys.includes('type') || managedKeys.includes('url')))) {
       return '';
     }

--- a/src/js/core/options_page.js
+++ b/src/js/core/options_page.js
@@ -22,6 +22,7 @@ class OptionsPage {
     $contextRuleEditor: document.getElementById('context-rule-editor'),
     $contextRuleGroup: document.getElementById('context-rule-group'),
     $contextRuleGroupLabel: document.getElementById('context-rule-group-label'),
+    $customUrlIframeOption: document.getElementById('custom-url-iframe-option'),
     $contextRules: document.getElementById('context-rules'),
     $contextRulesListManagedBadge: document.getElementById('context-rules-list-managed-badge'),
     $contextRulesManagedBadge: document.getElementById('context-rules-managed-badge'),
@@ -194,6 +195,7 @@ class OptionsPage {
     let showFocusOption = false;
     let showClearOption = false;
     let showBackgroundColorOption = false;
+    let showCustomUrlIframeOption = false;
     let showLocalFileOption = false;
     let showLocalFileDeleteButton = false;
     let showContextRulesOption = false;
@@ -208,6 +210,13 @@ class OptionsPage {
       showContextRulesOption = true;
       showFocusOption = true;
       showClearOption = true;
+    }
+
+    if (OptionsPage.#$elements.$type.options[OptionsPage.#$elements.$type.selectedIndex].value === 'custom_url_iframe') {
+      showContextRulesOption = true;
+      showCustomUrlIframeOption = true;
+      showFocusOption = true;
+      showClearOption = false;
     }
 
     if (OptionsPage.#$elements.$type.options[OptionsPage.#$elements.$type.selectedIndex].value === 'local_file') {
@@ -236,6 +245,7 @@ class OptionsPage {
     OptionsPage.#toggleVisibility(OptionsPage.#$elements.$focusOption, showFocusOption);
     OptionsPage.#toggleVisibility(OptionsPage.#$elements.$clearOption, showClearOption);
     OptionsPage.#toggleVisibility(OptionsPage.#$elements.$backgroundColorOption, showBackgroundColorOption);
+    OptionsPage.#toggleVisibility(OptionsPage.#$elements.$customUrlIframeOption, showCustomUrlIframeOption);
     OptionsPage.#toggleVisibility(OptionsPage.#$elements.$localFileOption, showLocalFileOption);
     OptionsPage.#toggleVisibility(OptionsPage.#$elements.$localFileDeleteButton, showLocalFileDeleteButton);
     OptionsPage.#toggleVisibility(OptionsPage.#$elements.$contextRulesOption, showContextRulesOption);

--- a/src/js/core/settings.js
+++ b/src/js/core/settings.js
@@ -15,7 +15,7 @@ class Settings {
    *
    * @type {string[]}
    */
-  static #supportedManagedTypes = ['background_color', 'custom_url', 'homepage'];
+  static #supportedManagedTypes = ['background_color', 'custom_url', 'custom_url_iframe', 'homepage'];
 
   /**
    * Regular expression used to validate managed background colors.


### PR DESCRIPTION
This MR adds a new "Custom URL (iFrame)" option that loads an URL inside an iFrame on the internal new-tab page so the address bar stays empty. The implementation reuses the existing custom URL behavior (validation, random pipe-separated URLs, context/container rules, focus handling). When the new option is selected, a warning is shown indicating that many websites cannot be embedded into iFrames due to security rules set.

I added the necessary translation strings for the (few) languages I speak. I could add a translation for the others but would not be able to verify their correctness.